### PR TITLE
fix wallet connection manager

### DIFF
--- a/Sources/SolanaWalletAdapterKit/ConnectionManager/WalletConnectionManager.swift
+++ b/Sources/SolanaWalletAdapterKit/ConnectionManager/WalletConnectionManager.swift
@@ -37,8 +37,9 @@ public class WalletConnectionManager {
         }
     }
 
+    @discardableResult
     public func pair<W: Wallet>(_ wallet: W.Type, for appIdentity: AppIdentity, cluster: Endpoint)
-        async throws-> any Wallet
+        async throws -> any Wallet
     {
         var walletInstance = wallet.init(for: appIdentity, cluster: cluster)
         try await pair(&walletInstance)


### PR DESCRIPTION
- private(set) to internal(set)
- returns walletinstance if using pair method without a preexisting wallet struct
- sorted keys for JSON encoder for deteministic identifiers