### PR TITLE
enforce lowercase URL scheme

### DIFF
--- a/Sources/SolanaWalletAdapterKit/Deeplink/DeeplinkFetcher.swift
+++ b/Sources/SolanaWalletAdapterKit/Deeplink/DeeplinkFetcher.swift
@@ -95,7 +95,7 @@ class DeeplinkFetcher {
     }
 
     func handleCallback(_ url: URL) -> Bool {
-        guard url.scheme == scheme else { return false }
+        guard url.scheme?.lowercased() == scheme.lowercased() else { return false }
 
         let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
 


### PR DESCRIPTION
- As we discussed previously, scheme comparison should be lowercase (compiler doesn't handle this)